### PR TITLE
Use ocamldep.opt and ocamllex.opt when available

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -107,6 +107,7 @@ public.USE_OCAMLFIND = false
     OCAMLOPT_OPT_EXISTS = $(CheckProg ocamlopt.opt)
     OCAMLOPT_EXISTS = $(or $(OCAMLOPT_OPT_EXISTS), $(CheckProg ocamlopt))
     OCAMLDEP_OPT_EXISTS = $(CheckProg ocamldep.opt)
+    OCAMLLEX_OPT_EXISTS = $(CheckProg ocamllex.opt)
     ConfMsgChecking(whether ocamlc understands the "z" warnings)
     OCAML_ACCEPTS_Z_WARNING =
         if $(OCAMLC_EXISTS)
@@ -130,7 +131,7 @@ public.LAZY_OCAMLFINDFLAGS = $`(if $(USE_OCAMLFIND), $(OCAMLFINDFLAGS))
 
 public.OCAMLDEP = $(if $(OCAMLDEP_OPT_EXISTS), ocamldep.opt, ocamldep)
 public.CAMLP4 = camlp4
-public.OCAMLLEX = ocamllex
+public.OCAMLLEX = $(if $(OCAMLLEX_OPT_EXISTS), ocamllex.opt, ocamllex)
 public.OCAMLLEXFLAGS = -q
 public.OCAMLYACC = ocamlyacc
 public.OCAMLYACCFLAGS =

--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -106,6 +106,7 @@ public.USE_OCAMLFIND = false
     OCAMLC_EXISTS = $(or $(OCAMLC_OPT_EXISTS), $(CheckProg ocamlc))
     OCAMLOPT_OPT_EXISTS = $(CheckProg ocamlopt.opt)
     OCAMLOPT_EXISTS = $(or $(OCAMLOPT_OPT_EXISTS), $(CheckProg ocamlopt))
+    OCAMLDEP_OPT_EXISTS = $(CheckProg ocamldep.opt)
     ConfMsgChecking(whether ocamlc understands the "z" warnings)
     OCAML_ACCEPTS_Z_WARNING =
         if $(OCAMLC_EXISTS)
@@ -127,7 +128,7 @@ public.OCAMLFIND = $`(if $(USE_OCAMLFIND), ocamlfind)
 public.OCAMLFINDFLAGS =
 public.LAZY_OCAMLFINDFLAGS = $`(if $(USE_OCAMLFIND), $(OCAMLFINDFLAGS))
 
-public.OCAMLDEP = ocamldep
+public.OCAMLDEP = $(if $(OCAMLDEP_OPT_EXISTS), ocamldep.opt, ocamldep)
 public.CAMLP4 = camlp4
 public.OCAMLLEX = ocamllex
 public.OCAMLLEXFLAGS = -q


### PR DESCRIPTION
omake-boot was using the bytecode ocamldep.