### PR TITLE
build a native omake-boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LN = ln -sf
 #
 # For bootstrapping
 #
-.PHONY: all bootstrap bootstrap-mingw install default
+.PHONY: all bootstrap-byte bootstrap-opt bootstrap bootstrap-mingw install default
 .PHONY: all-after-boot all-non-boot install-after-boot install-non-boot
 
 #
@@ -20,9 +20,16 @@ default:
 	@echo "       to build and install everything"
 	@exit 1
 
-bootstrap: boot/Makefile
+bootstrap-byte: boot/Makefile
 	@cd boot; $(MAKE) Makefile.dep; $(MAKE) omake
 	@$(LN) boot/omake omake-boot
+
+bootstrap-opt: boot/Makefile
+	@cd boot; $(MAKE) Makefile.dep; $(MAKE) omake PREFERRED=.opt
+	@$(LN) boot/omake omake-boot
+
+bootstrap:
+	ocamlopt.opt -v 2>/dev/null && $(MAKE) bootstrap-opt || $(MAKE) bootstrap-byte
 
 bootstrap-mingw:
 	@$(MAKE) boot/Makefile LN=cp

--- a/mk/make_gen
+++ b/mk/make_gen
@@ -74,10 +74,13 @@ MakeLinkExternal(srcdir, files) =
 MakeStaticCLibrary(name, files) =
     StaticCLibrary($(name), $(files))
 
-    private.cfiles = $(addsuffix .c, $(files))
-    private.hfiles = $(filter-exists $(addsuffix .h, $(files)))
-    private.ofiles = $(addsuffix $(ext_obj), $(files))
-    MAKEFILE_LINK += $(cfiles) $(hfiles)
+    private.src_cfiles = $(addsuffix .c, $(files))
+    private.cfiles = $(addprefix c_, $(src_cfiles))
+    private.cfiles = $(src_cfiles)
+    private.src_hfiles = $(filter-exists $(addsuffix .h, $(files)))
+    private.hfiles = $(addprefix c_, $(src_hfiles))
+    private.ofiles = $(addprefix c_, $(addsuffix $(ext_obj), $(files)))
+
     MAKEFILE_TEXT += $"""
 OFILES_$(name) = $(ofiles)
 
@@ -85,6 +88,15 @@ $(name)$$(EXT_LIB): $$(OFILES_$(name))
 	-$$(RM) $$@
 	$$(AR) $$(AROUT)$$@ $$(OFILES_$(name))
 """
+
+    foreach(name => ..., $(src_cfiles))
+        dst=c_$(name)
+        src=$(name)
+        MakeLinkFile($(dst), $(src))
+        $(dst): $(src)
+            ln-or-cp $< $@
+        export
+
     export
 
 ########################################################################
@@ -100,21 +112,32 @@ MakeOCamlProgram(name, files) =
     private.mlfiles = $(addsuffix .ml, $(files))
     private.mlifiles = $(filter-exists $(addsuffix .mli, $(files)))
     private.cmofiles = $(addsuffix .cmo, $(files))
+    private.cmxfiles = $(addsuffix .cmx, $(files))
     private.ocaml_libs = $(addsuffix .cma, $(basename $(OCAML_LIBS)))
+    private.ocaml_libs_opt = $(addsuffix .cmxa, $(basename $(OCAML_LIBS)))
     private.ocaml_other_libs = $(addsuffix .cma, $(OCAML_OTHER_LIBS))
+    private.ocaml_other_libs_opt = $(addsuffix .cmxa, $(OCAML_OTHER_LIBS))
     private.ocaml_other_libs = $(set-diff $(ocaml_other_libs), threads.cma)
+    private.ocaml_other_libs_opt = $(set-diff $(ocaml_other_libs_opt), threads.cmxa)
     private.ocaml_clibs = $(addsuffix $(ext_lib), $(basename $(OCAML_CLIBS)))
     private.ocaml_cclibs = $(mapprefix -cclib, $(ocaml_clibs))
     MAKEFILE_LINK += $(mlfiles) $(mlifiles)
     MAKEFILE_TEXT += $"""
 CMOFILES_$(name) = $(cmofiles)
+CMXFILES_$(name) = $(cmxfiles)
 OCAML_LIBS_$(name) = $(ocaml_libs)
+OCAML_LIBS_OPT_$(name) = $(ocaml_libs_opt)
 OCAML_OTHER_LIBS_$(name) = $(ocaml_other_libs)
+OCAML_OTHER_LIBS_OPT_$(name) = $(ocaml_other_libs_opt)
 OCAML_CLIBS_$(name) = $(ocaml_clibs)
 OCAML_CCLIBS_$(name) = $(ocaml_cclibs)
 
-$(name)$$(EXE): $$(CMOFILES_$(name)) $$(OCAML_LIBS_$(name)) $$(OCAML_CLIBS_$(name))
+$(name).byte$$(EXE): $$(CMOFILES_$(name)) $$(OCAML_LIBS_$(name)) $$(OCAML_CLIBS_$(name))
 	$$(OCAMLC) $$(OCAMLFLAGS) -custom -o $$@ $$(OCAML_CCLIBS_$(name)) $$(OCAML_OTHER_LIBS_$(name)) $$(THREADSLIB) $$(OCAML_LIBS_$(name)) $$(CMOFILES_$(name))
+$(name).opt$$(EXE): $$(CMXFILES_$(name)) $$(OCAML_LIBS_OPT_$(name)) $$(OCAML_CLIBS_$(name))
+	$$(OCAMLOPT) $$(OCAMLFLAGS) -o $$@ $$(OCAML_CCLIBS_$(name)) $$(OCAML_OTHER_LIBS_OPT_$(name)) $$(THREADSLIB) $$(OCAML_LIBS_OPT_$(name)) $$(CMXFILES_$(name))
+$(name)$$(EXE): $(name)$$(PREFERRED)$$(EXE)
+	$$(LN) $(name)$$(PREFERRED)$$(EXE) $$@
 """
     export
 
@@ -127,13 +150,17 @@ MakeOCamlLibrary(name, files) =
     private.mlfiles = $(addsuffix .ml, $(files))
     private.mlifiles = $(filter-exists $(addsuffix .mli, $(files)))
     private.cmofiles = $(addsuffix .cmo, $(files))
+    private.cmxfiles = $(addsuffix .cmx, $(files))
     MAKEFILE_LINK += $(mlfiles) $(mlifiles)
     MAKEFILE_TEXT += $"""
 CMOFILES_$(name) = $(cmofiles)
+CMXFILES_$(name) = $(cmxfiles)
 OCAML_LIB_FLAGS_$(name) = $(OCAML_LIB_FLAGS)
 
 $(name).cma: $$(CMOFILES_$(name))
 	$$(OCAMLC) $$(OCAMLFLAGS) $$(OCAML_LIB_FLAGS_$(name)) -a -o $$@ $$(CMOFILES_$(name))
+$(name).cmxa: $$(CMXFILES_$(name))
+	$$(OCAMLOPT) $$(OCAMLFLAGS) $$(OCAML_LIB_FLAGS_$(name)) -a -o $$@ $$(CMXFILES_$(name))
 """
     export
 
@@ -143,9 +170,10 @@ $(name).cma: $$(CMOFILES_$(name))
 MakeOCamlDepend(files, deps) =
     private.mlifiles = $(filter-exists $(addsuffix .mli, $(files)))
     private.cmofiles = $(addsuffix .cmo, $(files))
+    private.cmxfiles = $(addsuffix .cmx, $(files))
     private.cmifiles = $(addsuffix .cmi, $(removesuffix $(mlifiles)))
     MAKEFILE_TEXT += $"""
-$(cmofiles) $(cmifiles): $(deps)
+$(cmxfiles) $(cmofiles) $(cmifiles): $(deps)
 """
     export
 
@@ -237,8 +265,9 @@ CCOMPTYPE = cc
 
 OCAMLFLAGS = -w +a-4-32-30-42-40-41 -g $(OCAMLFLAGS_EXTRA)
 THREADSLIB =
+PREFERRED = .byte
 
-.SUFFIXES: .mll .mly .mli .ml .c .cmi .cmo .cma .o
+.SUFFIXES: .mll .mly .mli .ml .c .cmi .cmo .cmx .cma .cmxa .o
 
 .c.o:
 	inc=`ocamlc -where | tr -d '\015'`; $(CC) $(CFLAGS) -I"$$inc" -I"$$inc/caml" -c $*.c
@@ -273,8 +302,10 @@ CCOMPTYPE = msvc
 
 OCAMLFLAGS = -thread -w +a-4-32-30-42-40-41 -g $(OCAMLFLAGS_EXTRA)
 THREADSLIB = threads.cma
+THREADSLIB_OPT = threads.cmxa
+PREFERRED = .opt
 
-.SUFFIXES: .mll .mly .mli .ml .cmi .cmo
+.SUFFIXES: .mll .mly .mli .ml .cmi .cmo .cmx
 
 .c.obj:
 	$(CC) $(CFLAGS) -c $*.c
@@ -285,6 +316,7 @@ private.MAKEFILE_HEAD_COMMON = $'''
 # OCaml configuration
 #
 OCAMLC = ocamlc.opt
+OCAMLOPT = ocamlopt.opt
 OCAMLYACC = ocamlyacc
 OCAMLLEX = ocamllex.opt
 OCAMLDEP = ocamldep.opt
@@ -303,6 +335,8 @@ OCAMLDEP = ocamldep.opt
 .ml.cmo:
 	$(OCAMLC) $(OCAMLFLAGS) -c $*.ml
 
+.ml.cmx:
+	$(OCAMLOPT) $(OCAMLFLAGS) -c $*.ml
 #
 # The version.txt file
 #

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,8 +29,9 @@ CCOMPTYPE = cc
 
 OCAMLFLAGS = -w +a-4-32-30-42-40-41 -g $(OCAMLFLAGS_EXTRA)
 THREADSLIB =
+PREFERRED = .byte
 
-.SUFFIXES: .mll .mly .mli .ml .c .cmi .cmo .cma .o
+.SUFFIXES: .mll .mly .mli .ml .c .cmi .cmo .cmx .cma .cmxa .o
 
 .c.o:
 	inc=`ocamlc -where | tr -d '\015'`; $(CC) $(CFLAGS) -I"$$inc" -I"$$inc/caml" -c $*.c
@@ -40,6 +41,7 @@ THREADSLIB =
 # OCaml configuration
 #
 OCAMLC = ocamlc.opt
+OCAMLOPT = ocamlopt.opt
 OCAMLYACC = ocamlyacc
 OCAMLLEX = ocamllex.opt
 OCAMLDEP = ocamldep.opt
@@ -58,6 +60,8 @@ OCAMLDEP = ocamldep.opt
 .ml.cmo:
 	$(OCAMLC) $(OCAMLFLAGS) -c $*.ml
 
+.ml.cmx:
+	$(OCAMLOPT) $(OCAMLFLAGS) -c $*.ml
 #
 # The version.txt file
 #
@@ -65,79 +69,76 @@ version.txt:
 	@echo 0.0.boot > $@
 
 
-OFILES_clib = lm_heap$(EXT_OBJ) lm_channel$(EXT_OBJ) lm_printf$(EXT_OBJ) lm_ctype$(EXT_OBJ) lm_uname_ext$(EXT_OBJ) lm_unix_cutil$(EXT_OBJ) lm_compat_win32$(EXT_OBJ) readline$(EXT_OBJ) omake_shell_sys$(EXT_OBJ) omake_shell_spawn$(EXT_OBJ) fam_win32$(EXT_OBJ) fam_kqueue$(EXT_OBJ) fam_inotify$(EXT_OBJ) lm_notify$(EXT_OBJ) lm_termsize$(EXT_OBJ) lm_terminfo$(EXT_OBJ) lm_fs_case_sensitive$(EXT_OBJ)
+OFILES_clib = c_lm_heap$(EXT_OBJ) c_lm_channel$(EXT_OBJ) c_lm_printf$(EXT_OBJ) c_lm_ctype$(EXT_OBJ) c_lm_uname_ext$(EXT_OBJ) c_lm_unix_cutil$(EXT_OBJ) c_lm_compat_win32$(EXT_OBJ) c_readline$(EXT_OBJ) c_omake_shell_sys$(EXT_OBJ) c_omake_shell_spawn$(EXT_OBJ) c_fam_win32$(EXT_OBJ) c_fam_kqueue$(EXT_OBJ) c_fam_inotify$(EXT_OBJ) c_lm_notify$(EXT_OBJ) c_lm_termsize$(EXT_OBJ) c_lm_terminfo$(EXT_OBJ) c_lm_fs_case_sensitive$(EXT_OBJ)
 
 clib$(EXT_LIB): $(OFILES_clib)
 	-$(RM) $@
 	$(AR) $(AROUT)$@ $(OFILES_clib)
 
+c_lm_heap.c: ..$(slash)src$(slash)clib$(slash)lm_heap.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_heap.c c_lm_heap.c
+
+c_lm_channel.c: ..$(slash)src$(slash)clib$(slash)lm_channel.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_channel.c c_lm_channel.c
+
+c_lm_printf.c: ..$(slash)src$(slash)clib$(slash)lm_printf.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_printf.c c_lm_printf.c
+
+c_lm_ctype.c: ..$(slash)src$(slash)clib$(slash)lm_ctype.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_ctype.c c_lm_ctype.c
+
+c_lm_uname_ext.c: ..$(slash)src$(slash)clib$(slash)lm_uname_ext.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_uname_ext.c c_lm_uname_ext.c
+
+c_lm_unix_cutil.c: ..$(slash)src$(slash)clib$(slash)lm_unix_cutil.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_unix_cutil.c c_lm_unix_cutil.c
+
+c_lm_compat_win32.c: ..$(slash)src$(slash)clib$(slash)lm_compat_win32.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_compat_win32.c c_lm_compat_win32.c
+
+c_readline.c: ..$(slash)src$(slash)clib$(slash)readline.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)readline.c c_readline.c
+
+c_omake_shell_sys.c: ..$(slash)src$(slash)clib$(slash)omake_shell_sys.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)omake_shell_sys.c c_omake_shell_sys.c
+
+c_omake_shell_spawn.c: ..$(slash)src$(slash)clib$(slash)omake_shell_spawn.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)omake_shell_spawn.c c_omake_shell_spawn.c
+
+c_fam_win32.c: ..$(slash)src$(slash)clib$(slash)fam_win32.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)fam_win32.c c_fam_win32.c
+
+c_fam_kqueue.c: ..$(slash)src$(slash)clib$(slash)fam_kqueue.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)fam_kqueue.c c_fam_kqueue.c
+
+c_fam_inotify.c: ..$(slash)src$(slash)clib$(slash)fam_inotify.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)fam_inotify.c c_fam_inotify.c
+
+c_lm_notify.c: ..$(slash)src$(slash)clib$(slash)lm_notify.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_notify.c c_lm_notify.c
+
+c_lm_termsize.c: ..$(slash)src$(slash)clib$(slash)lm_termsize.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_termsize.c c_lm_termsize.c
+
+c_lm_terminfo.c: ..$(slash)src$(slash)clib$(slash)lm_terminfo.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_terminfo.c c_lm_terminfo.c
+
+c_lm_fs_case_sensitive.c: ..$(slash)src$(slash)clib$(slash)lm_fs_case_sensitive.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_fs_case_sensitive.c c_lm_fs_case_sensitive.c
+
 SRC_clib = ..$(slash)src$(slash)clib
 
-fam_inotify.c: $(SRC_clib)$(slash)fam_inotify.c
-	$(LN) $(SRC_clib)$(slash)fam_inotify.c fam_inotify.c
-
-fam_kqueue.c: $(SRC_clib)$(slash)fam_kqueue.c
-	$(LN) $(SRC_clib)$(slash)fam_kqueue.c fam_kqueue.c
-
-fam_win32.c: $(SRC_clib)$(slash)fam_win32.c
-	$(LN) $(SRC_clib)$(slash)fam_win32.c fam_win32.c
-
-lm_channel.c: $(SRC_clib)$(slash)lm_channel.c
-	$(LN) $(SRC_clib)$(slash)lm_channel.c lm_channel.c
-
-lm_compat_win32.c: $(SRC_clib)$(slash)lm_compat_win32.c
-	$(LN) $(SRC_clib)$(slash)lm_compat_win32.c lm_compat_win32.c
-
-lm_compat_win32.h: $(SRC_clib)$(slash)lm_compat_win32.h
-	$(LN) $(SRC_clib)$(slash)lm_compat_win32.h lm_compat_win32.h
-
-lm_ctype.c: $(SRC_clib)$(slash)lm_ctype.c
-	$(LN) $(SRC_clib)$(slash)lm_ctype.c lm_ctype.c
-
-lm_fs_case_sensitive.c: $(SRC_clib)$(slash)lm_fs_case_sensitive.c
-	$(LN) $(SRC_clib)$(slash)lm_fs_case_sensitive.c lm_fs_case_sensitive.c
-
-lm_heap.c: $(SRC_clib)$(slash)lm_heap.c
-	$(LN) $(SRC_clib)$(slash)lm_heap.c lm_heap.c
-
-lm_heap.h: $(SRC_clib)$(slash)lm_heap.h
-	$(LN) $(SRC_clib)$(slash)lm_heap.h lm_heap.h
-
-lm_notify.c: $(SRC_clib)$(slash)lm_notify.c
-	$(LN) $(SRC_clib)$(slash)lm_notify.c lm_notify.c
-
-lm_printf.c: $(SRC_clib)$(slash)lm_printf.c
-	$(LN) $(SRC_clib)$(slash)lm_printf.c lm_printf.c
-
-lm_terminfo.c: $(SRC_clib)$(slash)lm_terminfo.c
-	$(LN) $(SRC_clib)$(slash)lm_terminfo.c lm_terminfo.c
-
-lm_termsize.c: $(SRC_clib)$(slash)lm_termsize.c
-	$(LN) $(SRC_clib)$(slash)lm_termsize.c lm_termsize.c
-
-lm_uname_ext.c: $(SRC_clib)$(slash)lm_uname_ext.c
-	$(LN) $(SRC_clib)$(slash)lm_uname_ext.c lm_uname_ext.c
-
-lm_unix_cutil.c: $(SRC_clib)$(slash)lm_unix_cutil.c
-	$(LN) $(SRC_clib)$(slash)lm_unix_cutil.c lm_unix_cutil.c
-
-omake_shell_spawn.c: $(SRC_clib)$(slash)omake_shell_spawn.c
-	$(LN) $(SRC_clib)$(slash)omake_shell_spawn.c omake_shell_spawn.c
-
-omake_shell_sys.c: $(SRC_clib)$(slash)omake_shell_sys.c
-	$(LN) $(SRC_clib)$(slash)omake_shell_sys.c omake_shell_sys.c
-
-readline.c: $(SRC_clib)$(slash)readline.c
-	$(LN) $(SRC_clib)$(slash)readline.c readline.c
-
-ALLFILES_clib = fam_inotify.c fam_kqueue.c fam_win32.c lm_channel.c lm_compat_win32.c lm_compat_win32.h lm_ctype.c lm_fs_case_sensitive.c lm_heap.c lm_heap.h lm_notify.c lm_printf.c lm_terminfo.c lm_termsize.c lm_uname_ext.c lm_unix_cutil.c omake_shell_spawn.c omake_shell_sys.c readline.c
+ALLFILES_clib =  c_lm_heap.c c_lm_channel.c c_lm_printf.c c_lm_ctype.c c_lm_uname_ext.c c_lm_unix_cutil.c c_lm_compat_win32.c c_readline.c c_omake_shell_sys.c c_omake_shell_spawn.c c_fam_win32.c c_fam_kqueue.c c_fam_inotify.c c_lm_notify.c c_lm_termsize.c c_lm_terminfo.c c_lm_fs_case_sensitive.c
 
 
 CMOFILES_lm = lm_printf.cmo lm_debug.cmo lm_heap.cmo lm_list_util.cmo lm_array_util.cmo lm_set_sig.cmo lm_set.cmo lm_map_sig.cmo lm_map.cmo lm_int_set.cmo lm_termsize.cmo lm_terminfo.cmo lm_arg.cmo lm_index.cmo lm_thread_sig.cmo lm_thread_core.cmo lm_thread.cmo lm_string_util.cmo lm_string_set.cmo lm_hash.cmo lm_hash_code.cmo lm_symbol.cmo lm_location.cmo lm_position.cmo lm_filename_util.cmo lm_uname.cmo lm_thread_pool.cmo lm_channel.cmo lm_unix_util.cmo lm_db.cmo lm_notify.cmo lm_fs_case_sensitive.cmo lm_wild.cmo lm_readline.cmo lm_marshal.cmo lm_handle_table.cmo lm_int_handle_table.cmo lm_bitset.cmo lm_instrument.cmo
+CMXFILES_lm = lm_printf.cmx lm_debug.cmx lm_heap.cmx lm_list_util.cmx lm_array_util.cmx lm_set_sig.cmx lm_set.cmx lm_map_sig.cmx lm_map.cmx lm_int_set.cmx lm_termsize.cmx lm_terminfo.cmx lm_arg.cmx lm_index.cmx lm_thread_sig.cmx lm_thread_core.cmx lm_thread.cmx lm_string_util.cmx lm_string_set.cmx lm_hash.cmx lm_hash_code.cmx lm_symbol.cmx lm_location.cmx lm_position.cmx lm_filename_util.cmx lm_uname.cmx lm_thread_pool.cmx lm_channel.cmx lm_unix_util.cmx lm_db.cmx lm_notify.cmx lm_fs_case_sensitive.cmx lm_wild.cmx lm_readline.cmx lm_marshal.cmx lm_handle_table.cmx lm_int_handle_table.cmx lm_bitset.cmx lm_instrument.cmx
 OCAML_LIB_FLAGS_lm =
 
 lm.cma: $(CMOFILES_lm)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_lm) -a -o $@ $(CMOFILES_lm)
+lm.cmxa: $(CMXFILES_lm)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_lm) -a -o $@ $(CMXFILES_lm)
 
 lm_thread_pool.ml: ..$(slash)src$(slash)libmojave$(slash)lm_thread_pool_$(system).ml
 	$(LN) ..$(slash)src$(slash)libmojave$(slash)lm_thread_pool_$(system).ml lm_thread_pool.ml
@@ -370,10 +371,13 @@ ALLFILES_libmojave = lm_arg.ml lm_arg.mli lm_array_util.ml lm_array_util.mli lm_
 
 
 CMOFILES_frt = lm_hash_cons.cmo lm_lexer.cmo lm_parser.cmo lm_glob.cmo
+CMXFILES_frt = lm_hash_cons.cmx lm_lexer.cmx lm_parser.cmx lm_glob.cmx
 OCAML_LIB_FLAGS_frt =
 
 frt.cma: $(CMOFILES_frt)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_frt) -a -o $@ $(CMOFILES_frt)
+frt.cmxa: $(CMXFILES_frt)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_frt) -a -o $@ $(CMXFILES_frt)
 
 SRC_front = ..$(slash)src$(slash)front
 
@@ -405,19 +409,29 @@ ALLFILES_front = lm_glob.ml lm_glob.mli lm_hash_cons.ml lm_hash_cons.mli lm_lexe
 
 
 CMOFILES_omake_gen_magic = omake_gen_magic.cmo
+CMXFILES_omake_gen_magic = omake_gen_magic.cmx
 OCAML_LIBS_omake_gen_magic = lm.cma frt.cma
+OCAML_LIBS_OPT_omake_gen_magic = lm.cmxa frt.cmxa
 OCAML_OTHER_LIBS_omake_gen_magic = unix.cma
+OCAML_OTHER_LIBS_OPT_omake_gen_magic = unix.cmxa
 OCAML_CLIBS_omake_gen_magic = clib$(EXT_LIB)
 OCAML_CCLIBS_omake_gen_magic = -cclib clib$(EXT_LIB)
 
-omake_gen_magic$(EXE): $(CMOFILES_omake_gen_magic) $(OCAML_LIBS_omake_gen_magic) $(OCAML_CLIBS_omake_gen_magic)
+omake_gen_magic.byte$(EXE): $(CMOFILES_omake_gen_magic) $(OCAML_LIBS_omake_gen_magic) $(OCAML_CLIBS_omake_gen_magic)
 	$(OCAMLC) $(OCAMLFLAGS) -custom -o $@ $(OCAML_CCLIBS_omake_gen_magic) $(OCAML_OTHER_LIBS_omake_gen_magic) $(THREADSLIB) $(OCAML_LIBS_omake_gen_magic) $(CMOFILES_omake_gen_magic)
+omake_gen_magic.opt$(EXE): $(CMXFILES_omake_gen_magic) $(OCAML_LIBS_OPT_omake_gen_magic) $(OCAML_CLIBS_omake_gen_magic)
+	$(OCAMLOPT) $(OCAMLFLAGS) -o $@ $(OCAML_CCLIBS_omake_gen_magic) $(OCAML_OTHER_LIBS_OPT_omake_gen_magic) $(THREADSLIB) $(OCAML_LIBS_OPT_omake_gen_magic) $(CMXFILES_omake_gen_magic)
+omake_gen_magic$(EXE): omake_gen_magic$(PREFERRED)$(EXE)
+	$(LN) omake_gen_magic$(PREFERRED)$(EXE) $@
 
 CMOFILES_magic = omake_magic.cmo
+CMXFILES_magic = omake_magic.cmx
 OCAML_LIB_FLAGS_magic =
 
 magic.cma: $(CMOFILES_magic)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_magic) -a -o $@ $(CMOFILES_magic)
+magic.cmxa: $(CMXFILES_magic)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_magic) -a -o $@ $(CMXFILES_magic)
 
 GENMAGIC_DEPS = lm_filename_util.ml lm_hash.ml lm_location.ml lm_map.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache.ml omake_cache_type.ml omake_node.ml omake_command_digest.ml lm_filename_util.ml lm_hash.ml lm_location.ml lm_symbol.ml lm_map.ml lm_set.ml omake_node.ml omake_ir.ml lm_filename_util.ml lm_hash.ml lm_lexer.ml lm_location.ml lm_map.ml lm_parser.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache_type.ml omake_ir.ml omake_node.ml omake_env.ml version.txt
 MAGIC_FILES =    --cache-files lm_filename_util.ml lm_hash.ml lm_location.ml lm_map.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache.ml omake_cache_type.ml omake_node.ml omake_command_digest.ml    --omc-files lm_filename_util.ml lm_hash.ml lm_location.ml lm_symbol.ml lm_map.ml lm_set.ml omake_node.ml omake_ir.ml    --omo-files lm_filename_util.ml lm_hash.ml lm_lexer.ml lm_location.ml lm_map.ml lm_parser.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache_type.ml omake_ir.ml omake_node.ml omake_env.ml
@@ -434,12 +448,15 @@ ALLFILES_magic = omake_gen_magic.ml
 
 
 CMOFILES_ir = omake_options.cmo omake_symbol.cmo omake_state.cmo omake_node_type.cmo omake_node_sig.cmo omake_node.cmo omake_install.cmo omake_ir.cmo omake_var.cmo omake_ir_util.cmo omake_ir_print.cmo omake_ir_free_vars.cmo omake_lexer.cmo omake_parser.cmo omake_value_type.cmo omake_command_type.cmo omake_value_util.cmo omake_value_print.cmo omake_pos.cmo omake_shell_type.cmo omake_command.cmo omake_cache_type.cmo omake_cache.cmo
+CMXFILES_ir = omake_options.cmx omake_symbol.cmx omake_state.cmx omake_node_type.cmx omake_node_sig.cmx omake_node.cmx omake_install.cmx omake_ir.cmx omake_var.cmx omake_ir_util.cmx omake_ir_print.cmx omake_ir_free_vars.cmx omake_lexer.cmx omake_parser.cmx omake_value_type.cmx omake_command_type.cmx omake_value_util.cmx omake_value_print.cmx omake_pos.cmx omake_shell_type.cmx omake_command.cmx omake_cache_type.cmx omake_cache.cmx
 OCAML_LIB_FLAGS_ir =
 
 ir.cma: $(CMOFILES_ir)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ir) -a -o $@ $(CMOFILES_ir)
+ir.cmxa: $(CMXFILES_ir)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ir) -a -o $@ $(CMXFILES_ir)
 
-omake_options.cmo omake_symbol.cmo omake_state.cmo omake_node_type.cmo omake_node_sig.cmo omake_node.cmo omake_install.cmo omake_ir.cmo omake_var.cmo omake_ir_util.cmo omake_ir_print.cmo omake_ir_free_vars.cmo omake_lexer.cmo omake_parser.cmo omake_value_type.cmo omake_command_type.cmo omake_value_util.cmo omake_value_print.cmo omake_pos.cmo omake_shell_type.cmo omake_command.cmo omake_cache_type.cmo omake_cache.cmo omake_options.cmi omake_state.cmi omake_node.cmi omake_install.cmi omake_var.cmi omake_ir_print.cmi omake_ir_free_vars.cmi omake_command_type.cmi omake_value_util.cmi omake_value_print.cmi omake_pos.cmi omake_command.cmi omake_cache.cmi: magic.cma
+omake_options.cmx omake_symbol.cmx omake_state.cmx omake_node_type.cmx omake_node_sig.cmx omake_node.cmx omake_install.cmx omake_ir.cmx omake_var.cmx omake_ir_util.cmx omake_ir_print.cmx omake_ir_free_vars.cmx omake_lexer.cmx omake_parser.cmx omake_value_type.cmx omake_command_type.cmx omake_value_util.cmx omake_value_print.cmx omake_pos.cmx omake_shell_type.cmx omake_command.cmx omake_cache_type.cmx omake_cache.cmx omake_options.cmo omake_symbol.cmo omake_state.cmo omake_node_type.cmo omake_node_sig.cmo omake_node.cmo omake_install.cmo omake_ir.cmo omake_var.cmo omake_ir_util.cmo omake_ir_print.cmo omake_ir_free_vars.cmo omake_lexer.cmo omake_parser.cmo omake_value_type.cmo omake_command_type.cmo omake_value_util.cmo omake_value_print.cmo omake_pos.cmo omake_shell_type.cmo omake_command.cmo omake_cache_type.cmo omake_cache.cmo omake_options.cmi omake_state.cmi omake_node.cmi omake_install.cmi omake_var.cmi omake_ir_print.cmi omake_ir_free_vars.cmi omake_command_type.cmi omake_value_util.cmi omake_value_print.cmi omake_pos.cmi omake_command.cmi omake_cache.cmi: magic.cma
 
 SRC_ir = ..$(slash)src$(slash)ir
 
@@ -555,10 +572,13 @@ ALLFILES_ir = omake_cache.ml omake_cache.mli omake_cache_type.ml omake_command.m
 
 
 CMOFILES_exec = omake_exec_id.cmo omake_exec_type.cmo omake_exec_print.cmo omake_exec_util.cmo omake_exec_local.cmo omake_exec_remote.cmo omake_exec_notify.cmo omake_exec.cmo
+CMXFILES_exec = omake_exec_id.cmx omake_exec_type.cmx omake_exec_print.cmx omake_exec_util.cmx omake_exec_local.cmx omake_exec_remote.cmx omake_exec_notify.cmx omake_exec.cmx
 OCAML_LIB_FLAGS_exec =
 
 exec.cma: $(CMOFILES_exec)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_exec) -a -o $@ $(CMOFILES_exec)
+exec.cmxa: $(CMXFILES_exec)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_exec) -a -o $@ $(CMXFILES_exec)
 
 SRC_exec = ..$(slash)src$(slash)exec
 
@@ -611,10 +631,13 @@ ALLFILES_exec = omake_exec.ml omake_exec.mli omake_exec_id.ml omake_exec_id.mli 
 
 
 CMOFILES_ast = omake_ast.cmo omake_ast_util.cmo omake_ast_print.cmo
+CMXFILES_ast = omake_ast.cmx omake_ast_util.cmx omake_ast_print.cmx
 OCAML_LIB_FLAGS_ast =
 
 ast.cma: $(CMOFILES_ast)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ast) -a -o $@ $(CMOFILES_ast)
+ast.cmxa: $(CMXFILES_ast)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ast) -a -o $@ $(CMXFILES_ast)
 
 SRC_ast = ..$(slash)src$(slash)ast
 
@@ -637,19 +660,29 @@ ALLFILES_ast = omake_ast.ml omake_ast_print.ml omake_ast_print.mli omake_ast_uti
 
 
 CMOFILES_omake_gen_parse = omake_gen_parse.cmo
+CMXFILES_omake_gen_parse = omake_gen_parse.cmx
 OCAML_LIBS_omake_gen_parse =
+OCAML_LIBS_OPT_omake_gen_parse =
 OCAML_OTHER_LIBS_omake_gen_parse = unix.cma
+OCAML_OTHER_LIBS_OPT_omake_gen_parse = unix.cmxa
 OCAML_CLIBS_omake_gen_parse =
 OCAML_CCLIBS_omake_gen_parse =
 
-omake_gen_parse$(EXE): $(CMOFILES_omake_gen_parse) $(OCAML_LIBS_omake_gen_parse) $(OCAML_CLIBS_omake_gen_parse)
+omake_gen_parse.byte$(EXE): $(CMOFILES_omake_gen_parse) $(OCAML_LIBS_omake_gen_parse) $(OCAML_CLIBS_omake_gen_parse)
 	$(OCAMLC) $(OCAMLFLAGS) -custom -o $@ $(OCAML_CCLIBS_omake_gen_parse) $(OCAML_OTHER_LIBS_omake_gen_parse) $(THREADSLIB) $(OCAML_LIBS_omake_gen_parse) $(CMOFILES_omake_gen_parse)
+omake_gen_parse.opt$(EXE): $(CMXFILES_omake_gen_parse) $(OCAML_LIBS_OPT_omake_gen_parse) $(OCAML_CLIBS_omake_gen_parse)
+	$(OCAMLOPT) $(OCAMLFLAGS) -o $@ $(OCAML_CCLIBS_omake_gen_parse) $(OCAML_OTHER_LIBS_OPT_omake_gen_parse) $(THREADSLIB) $(OCAML_LIBS_OPT_omake_gen_parse) $(CMXFILES_omake_gen_parse)
+omake_gen_parse$(EXE): omake_gen_parse$(PREFERRED)$(EXE)
+	$(LN) omake_gen_parse$(PREFERRED)$(EXE) $@
 
 CMOFILES_env = omake_env.cmo omake_exn_print.cmo omake_ast_parse.cmo omake_ast_lex.cmo omake_exp_parse.cmo omake_exp_lex.cmo omake_ir_ast.cmo omake_ir_semant.cmo omake_command_digest.cmo
+CMXFILES_env = omake_env.cmx omake_exn_print.cmx omake_ast_parse.cmx omake_ast_lex.cmx omake_exp_parse.cmx omake_exp_lex.cmx omake_ir_ast.cmx omake_ir_semant.cmx omake_command_digest.cmx
 OCAML_LIB_FLAGS_env =
 
 env.cma: $(CMOFILES_env)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_env) -a -o $@ $(CMOFILES_env)
+env.cmxa: $(CMXFILES_env)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_env) -a -o $@ $(CMXFILES_env)
 
 GENPARSE = omake_gen_parse
 omake_ast_parse.mly: $(GENPARSE)$(EXE) omake_ast_parse.input
@@ -673,7 +706,7 @@ omake_ast_parse.input: ..$(slash)src$(slash)env$(slash)omake_ast_parse.input
 omake_exp_parse.mly: ..$(slash)src$(slash)env$(slash)omake_exp_parse.mly
 	$(LN) ..$(slash)src$(slash)env$(slash)omake_exp_parse.mly omake_exp_parse.mly
 
-omake_env.cmo omake_exn_print.cmo omake_ast_parse.cmo omake_ast_lex.cmo omake_exp_parse.cmo omake_exp_lex.cmo omake_ir_ast.cmo omake_ir_semant.cmo omake_command_digest.cmo omake_env.cmi omake_exn_print.cmi omake_ast_parse.cmi omake_ast_lex.cmi omake_exp_parse.cmi omake_exp_lex.cmi omake_ir_ast.cmi omake_ir_semant.cmi omake_command_digest.cmi: magic.cma
+omake_env.cmx omake_exn_print.cmx omake_ast_parse.cmx omake_ast_lex.cmx omake_exp_parse.cmx omake_exp_lex.cmx omake_ir_ast.cmx omake_ir_semant.cmx omake_command_digest.cmx omake_env.cmo omake_exn_print.cmo omake_ast_parse.cmo omake_ast_lex.cmo omake_exp_parse.cmo omake_exp_lex.cmo omake_ir_ast.cmo omake_ir_semant.cmo omake_command_digest.cmo omake_env.cmi omake_exn_print.cmi omake_ast_parse.cmi omake_ast_lex.cmi omake_exp_parse.cmi omake_exp_lex.cmi omake_ir_ast.cmi omake_ir_semant.cmi omake_command_digest.cmi: magic.cma
 
 Makefile.dep: omake_ast_lex.ml omake_ast_parse.mly omake_ast_parse.mli omake_ast_parse.ml omake_exp_parse.ml omake_exp_parse.mli
 
@@ -725,10 +758,13 @@ ALLFILES_env = omake_ast_lex.mli omake_command_digest.ml omake_command_digest.ml
 
 
 CMOFILES_shell = omake_shell_parse.cmo omake_shell_lex.cmo omake_shell_spawn.cmo omake_shell_sys_type.cmo omake_shell_sys.cmo omake_shell_job.cmo omake_shell_completion.cmo
+CMXFILES_shell = omake_shell_parse.cmx omake_shell_lex.cmx omake_shell_spawn.cmx omake_shell_sys_type.cmx omake_shell_sys.cmx omake_shell_job.cmx omake_shell_completion.cmx
 OCAML_LIB_FLAGS_shell =
 
 shell.cma: $(CMOFILES_shell)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_shell) -a -o $@ $(CMOFILES_shell)
+shell.cmxa: $(CMXFILES_shell)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_shell) -a -o $@ $(CMXFILES_shell)
 
 omake_shell_parse.ml: omake_shell_parse.mly
 omake_shell_parse.mli: omake_shell_parse.mly
@@ -778,10 +814,13 @@ ALLFILES_shell = omake_shell_completion.ml omake_shell_completion.mli omake_shel
 
 
 CMOFILES_eval = omake_eval.cmo omake_value.cmo
+CMXFILES_eval = omake_eval.cmx omake_value.cmx
 OCAML_LIB_FLAGS_eval =
 
 eval.cma: $(CMOFILES_eval)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_eval) -a -o $@ $(CMOFILES_eval)
+eval.cmxa: $(CMXFILES_eval)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_eval) -a -o $@ $(CMXFILES_eval)
 
 SRC_eval = ..$(slash)src$(slash)eval
 
@@ -801,12 +840,15 @@ ALLFILES_eval = omake_eval.ml omake_eval.mli omake_value.ml omake_value.mli
 
 
 CMOFILES_build = omake_rule.cmo omake_build_type.cmo omake_build_tee.cmo omake_build_util.cmo omake_builtin_type.cmo omake_target.cmo omake_builtin.cmo omake_build.cmo
+CMXFILES_build = omake_rule.cmx omake_build_type.cmx omake_build_tee.cmx omake_build_util.cmx omake_builtin_type.cmx omake_target.cmx omake_builtin.cmx omake_build.cmx
 OCAML_LIB_FLAGS_build =
 
 build.cma: $(CMOFILES_build)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_build) -a -o $@ $(CMOFILES_build)
+build.cmxa: $(CMXFILES_build)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_build) -a -o $@ $(CMXFILES_build)
 
-omake_rule.cmo omake_build_type.cmo omake_build_tee.cmo omake_build_util.cmo omake_builtin_type.cmo omake_target.cmo omake_builtin.cmo omake_build.cmo omake_rule.cmi omake_build_tee.cmi omake_build_util.cmi omake_target.cmi omake_builtin.cmi omake_build.cmi: magic.cma
+omake_rule.cmx omake_build_type.cmx omake_build_tee.cmx omake_build_util.cmx omake_builtin_type.cmx omake_target.cmx omake_builtin.cmx omake_build.cmx omake_rule.cmo omake_build_type.cmo omake_build_tee.cmo omake_build_util.cmo omake_builtin_type.cmo omake_target.cmo omake_builtin.cmo omake_build.cmo omake_rule.cmi omake_build_tee.cmi omake_build_util.cmi omake_target.cmi omake_builtin.cmi omake_build.cmi: magic.cma
 
 SRC_build = ..$(slash)src$(slash)build
 
@@ -856,12 +898,15 @@ ALLFILES_build = omake_build.ml omake_build.mli omake_build_tee.ml omake_build_t
 
 
 CMOFILES_builtin = omake_printf.cmo omake_builtin_util.cmo omake_builtin_base.cmo omake_builtin_arith.cmo omake_builtin_file.cmo omake_builtin_fun.cmo omake_builtin_io.cmo omake_builtin_io_fun.cmo omake_builtin_sys.cmo omake_builtin_target.cmo omake_builtin_shell.cmo omake_builtin_rule.cmo omake_builtin_object.cmo omake_builtin_test.cmo omake_builtin_ocamldep.cmo
+CMXFILES_builtin = omake_printf.cmx omake_builtin_util.cmx omake_builtin_base.cmx omake_builtin_arith.cmx omake_builtin_file.cmx omake_builtin_fun.cmx omake_builtin_io.cmx omake_builtin_io_fun.cmx omake_builtin_sys.cmx omake_builtin_target.cmx omake_builtin_shell.cmx omake_builtin_rule.cmx omake_builtin_object.cmx omake_builtin_test.cmx omake_builtin_ocamldep.cmx
 OCAML_LIB_FLAGS_builtin = -linkall
 
 builtin.cma: $(CMOFILES_builtin)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_builtin) -a -o $@ $(CMOFILES_builtin)
+builtin.cmxa: $(CMXFILES_builtin)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_builtin) -a -o $@ $(CMXFILES_builtin)
 
-omake_printf.cmo omake_builtin_util.cmo omake_builtin_base.cmo omake_builtin_arith.cmo omake_builtin_file.cmo omake_builtin_fun.cmo omake_builtin_io.cmo omake_builtin_io_fun.cmo omake_builtin_sys.cmo omake_builtin_target.cmo omake_builtin_shell.cmo omake_builtin_rule.cmo omake_builtin_object.cmo omake_builtin_test.cmo omake_builtin_ocamldep.cmo omake_printf.cmi omake_builtin_util.cmi omake_builtin_base.cmi omake_builtin_arith.cmi omake_builtin_file.cmi omake_builtin_fun.cmi omake_builtin_io.cmi omake_builtin_io_fun.cmi omake_builtin_sys.cmi omake_builtin_target.cmi omake_builtin_shell.cmi omake_builtin_rule.cmi omake_builtin_object.cmi omake_builtin_test.cmi: magic.cma
+omake_printf.cmx omake_builtin_util.cmx omake_builtin_base.cmx omake_builtin_arith.cmx omake_builtin_file.cmx omake_builtin_fun.cmx omake_builtin_io.cmx omake_builtin_io_fun.cmx omake_builtin_sys.cmx omake_builtin_target.cmx omake_builtin_shell.cmx omake_builtin_rule.cmx omake_builtin_object.cmx omake_builtin_test.cmx omake_builtin_ocamldep.cmx omake_printf.cmo omake_builtin_util.cmo omake_builtin_base.cmo omake_builtin_arith.cmo omake_builtin_file.cmo omake_builtin_fun.cmo omake_builtin_io.cmo omake_builtin_io_fun.cmo omake_builtin_sys.cmo omake_builtin_target.cmo omake_builtin_shell.cmo omake_builtin_rule.cmo omake_builtin_object.cmo omake_builtin_test.cmo omake_builtin_ocamldep.cmo omake_printf.cmi omake_builtin_util.cmi omake_builtin_base.cmi omake_builtin_arith.cmi omake_builtin_file.cmi omake_builtin_fun.cmi omake_builtin_io.cmi omake_builtin_io_fun.cmi omake_builtin_sys.cmi omake_builtin_target.cmi omake_builtin_shell.cmi omake_builtin_rule.cmi omake_builtin_object.cmi omake_builtin_test.cmi: magic.cma
 
 SRC_builtin = ..$(slash)src$(slash)builtin
 
@@ -956,15 +1001,22 @@ ALLFILES_builtin = omake_builtin_arith.ml omake_builtin_arith.mli omake_builtin_
 
 
 CMOFILES_omake = omake_main_util.cmo omake_shell.cmo omake_main.cmo
+CMXFILES_omake = omake_main_util.cmx omake_shell.cmx omake_main.cmx
 OCAML_LIBS_omake = lm.cma frt.cma magic.cma ast.cma ir.cma env.cma exec.cma eval.cma shell.cma build.cma builtin.cma
+OCAML_LIBS_OPT_omake = lm.cmxa frt.cmxa magic.cmxa ast.cmxa ir.cmxa env.cmxa exec.cmxa eval.cmxa shell.cmxa build.cmxa builtin.cmxa
 OCAML_OTHER_LIBS_omake = unix.cma
+OCAML_OTHER_LIBS_OPT_omake = unix.cmxa
 OCAML_CLIBS_omake = clib$(EXT_LIB)
 OCAML_CCLIBS_omake = -cclib clib$(EXT_LIB)
 
-omake$(EXE): $(CMOFILES_omake) $(OCAML_LIBS_omake) $(OCAML_CLIBS_omake)
+omake.byte$(EXE): $(CMOFILES_omake) $(OCAML_LIBS_omake) $(OCAML_CLIBS_omake)
 	$(OCAMLC) $(OCAMLFLAGS) -custom -o $@ $(OCAML_CCLIBS_omake) $(OCAML_OTHER_LIBS_omake) $(THREADSLIB) $(OCAML_LIBS_omake) $(CMOFILES_omake)
+omake.opt$(EXE): $(CMXFILES_omake) $(OCAML_LIBS_OPT_omake) $(OCAML_CLIBS_omake)
+	$(OCAMLOPT) $(OCAMLFLAGS) -o $@ $(OCAML_CCLIBS_omake) $(OCAML_OTHER_LIBS_OPT_omake) $(THREADSLIB) $(OCAML_LIBS_OPT_omake) $(CMXFILES_omake)
+omake$(EXE): omake$(PREFERRED)$(EXE)
+	$(LN) omake$(PREFERRED)$(EXE) $@
 
-omake_main_util.cmo omake_shell.cmo omake_main.cmo omake_shell.cmi omake_main.cmi: magic.cma
+omake_main_util.cmx omake_shell.cmx omake_main.cmx omake_main_util.cmo omake_shell.cmo omake_main.cmo omake_shell.cmi omake_main.cmi: magic.cma
 
 SRC_main = ..$(slash)src$(slash)main
 

--- a/src/Makefile.nt
+++ b/src/Makefile.nt
@@ -27,8 +27,10 @@ CCOMPTYPE = msvc
 
 OCAMLFLAGS = -thread -w +a-4-32-30-42-40-41 -g $(OCAMLFLAGS_EXTRA)
 THREADSLIB = threads.cma
+THREADSLIB_OPT = threads.cmxa
+PREFERRED = .opt
 
-.SUFFIXES: .mll .mly .mli .ml .cmi .cmo
+.SUFFIXES: .mll .mly .mli .ml .cmi .cmo .cmx
 
 .c.obj:
 	$(CC) $(CFLAGS) -c $*.c
@@ -38,6 +40,7 @@ THREADSLIB = threads.cma
 # OCaml configuration
 #
 OCAMLC = ocamlc.opt
+OCAMLOPT = ocamlopt.opt
 OCAMLYACC = ocamlyacc
 OCAMLLEX = ocamllex.opt
 OCAMLDEP = ocamldep.opt
@@ -56,6 +59,8 @@ OCAMLDEP = ocamldep.opt
 .ml.cmo:
 	$(OCAMLC) $(OCAMLFLAGS) -c $*.ml
 
+.ml.cmx:
+	$(OCAMLOPT) $(OCAMLFLAGS) -c $*.ml
 #
 # The version.txt file
 #
@@ -63,79 +68,76 @@ version.txt:
 	@echo 0.0.boot > $@
 
 
-OFILES_clib = lm_heap$(EXT_OBJ) lm_channel$(EXT_OBJ) lm_printf$(EXT_OBJ) lm_ctype$(EXT_OBJ) lm_uname_ext$(EXT_OBJ) lm_unix_cutil$(EXT_OBJ) lm_compat_win32$(EXT_OBJ) readline$(EXT_OBJ) omake_shell_sys$(EXT_OBJ) omake_shell_spawn$(EXT_OBJ) fam_win32$(EXT_OBJ) fam_kqueue$(EXT_OBJ) fam_inotify$(EXT_OBJ) lm_notify$(EXT_OBJ) lm_termsize$(EXT_OBJ) lm_terminfo$(EXT_OBJ) lm_fs_case_sensitive$(EXT_OBJ)
+OFILES_clib = c_lm_heap$(EXT_OBJ) c_lm_channel$(EXT_OBJ) c_lm_printf$(EXT_OBJ) c_lm_ctype$(EXT_OBJ) c_lm_uname_ext$(EXT_OBJ) c_lm_unix_cutil$(EXT_OBJ) c_lm_compat_win32$(EXT_OBJ) c_readline$(EXT_OBJ) c_omake_shell_sys$(EXT_OBJ) c_omake_shell_spawn$(EXT_OBJ) c_fam_win32$(EXT_OBJ) c_fam_kqueue$(EXT_OBJ) c_fam_inotify$(EXT_OBJ) c_lm_notify$(EXT_OBJ) c_lm_termsize$(EXT_OBJ) c_lm_terminfo$(EXT_OBJ) c_lm_fs_case_sensitive$(EXT_OBJ)
 
 clib$(EXT_LIB): $(OFILES_clib)
 	-$(RM) $@
 	$(AR) $(AROUT)$@ $(OFILES_clib)
 
+c_lm_heap.c: ..$(slash)src$(slash)clib$(slash)lm_heap.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_heap.c c_lm_heap.c
+
+c_lm_channel.c: ..$(slash)src$(slash)clib$(slash)lm_channel.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_channel.c c_lm_channel.c
+
+c_lm_printf.c: ..$(slash)src$(slash)clib$(slash)lm_printf.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_printf.c c_lm_printf.c
+
+c_lm_ctype.c: ..$(slash)src$(slash)clib$(slash)lm_ctype.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_ctype.c c_lm_ctype.c
+
+c_lm_uname_ext.c: ..$(slash)src$(slash)clib$(slash)lm_uname_ext.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_uname_ext.c c_lm_uname_ext.c
+
+c_lm_unix_cutil.c: ..$(slash)src$(slash)clib$(slash)lm_unix_cutil.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_unix_cutil.c c_lm_unix_cutil.c
+
+c_lm_compat_win32.c: ..$(slash)src$(slash)clib$(slash)lm_compat_win32.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_compat_win32.c c_lm_compat_win32.c
+
+c_readline.c: ..$(slash)src$(slash)clib$(slash)readline.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)readline.c c_readline.c
+
+c_omake_shell_sys.c: ..$(slash)src$(slash)clib$(slash)omake_shell_sys.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)omake_shell_sys.c c_omake_shell_sys.c
+
+c_omake_shell_spawn.c: ..$(slash)src$(slash)clib$(slash)omake_shell_spawn.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)omake_shell_spawn.c c_omake_shell_spawn.c
+
+c_fam_win32.c: ..$(slash)src$(slash)clib$(slash)fam_win32.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)fam_win32.c c_fam_win32.c
+
+c_fam_kqueue.c: ..$(slash)src$(slash)clib$(slash)fam_kqueue.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)fam_kqueue.c c_fam_kqueue.c
+
+c_fam_inotify.c: ..$(slash)src$(slash)clib$(slash)fam_inotify.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)fam_inotify.c c_fam_inotify.c
+
+c_lm_notify.c: ..$(slash)src$(slash)clib$(slash)lm_notify.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_notify.c c_lm_notify.c
+
+c_lm_termsize.c: ..$(slash)src$(slash)clib$(slash)lm_termsize.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_termsize.c c_lm_termsize.c
+
+c_lm_terminfo.c: ..$(slash)src$(slash)clib$(slash)lm_terminfo.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_terminfo.c c_lm_terminfo.c
+
+c_lm_fs_case_sensitive.c: ..$(slash)src$(slash)clib$(slash)lm_fs_case_sensitive.c
+	$(LN) ..$(slash)src$(slash)clib$(slash)lm_fs_case_sensitive.c c_lm_fs_case_sensitive.c
+
 SRC_clib = ..$(slash)src$(slash)clib
 
-fam_inotify.c: $(SRC_clib)$(slash)fam_inotify.c
-	$(LN) $(SRC_clib)$(slash)fam_inotify.c fam_inotify.c
-
-fam_kqueue.c: $(SRC_clib)$(slash)fam_kqueue.c
-	$(LN) $(SRC_clib)$(slash)fam_kqueue.c fam_kqueue.c
-
-fam_win32.c: $(SRC_clib)$(slash)fam_win32.c
-	$(LN) $(SRC_clib)$(slash)fam_win32.c fam_win32.c
-
-lm_channel.c: $(SRC_clib)$(slash)lm_channel.c
-	$(LN) $(SRC_clib)$(slash)lm_channel.c lm_channel.c
-
-lm_compat_win32.c: $(SRC_clib)$(slash)lm_compat_win32.c
-	$(LN) $(SRC_clib)$(slash)lm_compat_win32.c lm_compat_win32.c
-
-lm_compat_win32.h: $(SRC_clib)$(slash)lm_compat_win32.h
-	$(LN) $(SRC_clib)$(slash)lm_compat_win32.h lm_compat_win32.h
-
-lm_ctype.c: $(SRC_clib)$(slash)lm_ctype.c
-	$(LN) $(SRC_clib)$(slash)lm_ctype.c lm_ctype.c
-
-lm_fs_case_sensitive.c: $(SRC_clib)$(slash)lm_fs_case_sensitive.c
-	$(LN) $(SRC_clib)$(slash)lm_fs_case_sensitive.c lm_fs_case_sensitive.c
-
-lm_heap.c: $(SRC_clib)$(slash)lm_heap.c
-	$(LN) $(SRC_clib)$(slash)lm_heap.c lm_heap.c
-
-lm_heap.h: $(SRC_clib)$(slash)lm_heap.h
-	$(LN) $(SRC_clib)$(slash)lm_heap.h lm_heap.h
-
-lm_notify.c: $(SRC_clib)$(slash)lm_notify.c
-	$(LN) $(SRC_clib)$(slash)lm_notify.c lm_notify.c
-
-lm_printf.c: $(SRC_clib)$(slash)lm_printf.c
-	$(LN) $(SRC_clib)$(slash)lm_printf.c lm_printf.c
-
-lm_terminfo.c: $(SRC_clib)$(slash)lm_terminfo.c
-	$(LN) $(SRC_clib)$(slash)lm_terminfo.c lm_terminfo.c
-
-lm_termsize.c: $(SRC_clib)$(slash)lm_termsize.c
-	$(LN) $(SRC_clib)$(slash)lm_termsize.c lm_termsize.c
-
-lm_uname_ext.c: $(SRC_clib)$(slash)lm_uname_ext.c
-	$(LN) $(SRC_clib)$(slash)lm_uname_ext.c lm_uname_ext.c
-
-lm_unix_cutil.c: $(SRC_clib)$(slash)lm_unix_cutil.c
-	$(LN) $(SRC_clib)$(slash)lm_unix_cutil.c lm_unix_cutil.c
-
-omake_shell_spawn.c: $(SRC_clib)$(slash)omake_shell_spawn.c
-	$(LN) $(SRC_clib)$(slash)omake_shell_spawn.c omake_shell_spawn.c
-
-omake_shell_sys.c: $(SRC_clib)$(slash)omake_shell_sys.c
-	$(LN) $(SRC_clib)$(slash)omake_shell_sys.c omake_shell_sys.c
-
-readline.c: $(SRC_clib)$(slash)readline.c
-	$(LN) $(SRC_clib)$(slash)readline.c readline.c
-
-ALLFILES_clib = fam_inotify.c fam_kqueue.c fam_win32.c lm_channel.c lm_compat_win32.c lm_compat_win32.h lm_ctype.c lm_fs_case_sensitive.c lm_heap.c lm_heap.h lm_notify.c lm_printf.c lm_terminfo.c lm_termsize.c lm_uname_ext.c lm_unix_cutil.c omake_shell_spawn.c omake_shell_sys.c readline.c
+ALLFILES_clib =  c_lm_heap.c c_lm_channel.c c_lm_printf.c c_lm_ctype.c c_lm_uname_ext.c c_lm_unix_cutil.c c_lm_compat_win32.c c_readline.c c_omake_shell_sys.c c_omake_shell_spawn.c c_fam_win32.c c_fam_kqueue.c c_fam_inotify.c c_lm_notify.c c_lm_termsize.c c_lm_terminfo.c c_lm_fs_case_sensitive.c
 
 
 CMOFILES_lm = lm_printf.cmo lm_debug.cmo lm_heap.cmo lm_list_util.cmo lm_array_util.cmo lm_set_sig.cmo lm_set.cmo lm_map_sig.cmo lm_map.cmo lm_int_set.cmo lm_termsize.cmo lm_terminfo.cmo lm_arg.cmo lm_index.cmo lm_thread_sig.cmo lm_thread_core.cmo lm_thread.cmo lm_string_util.cmo lm_string_set.cmo lm_hash.cmo lm_hash_code.cmo lm_symbol.cmo lm_location.cmo lm_position.cmo lm_filename_util.cmo lm_uname.cmo lm_thread_pool.cmo lm_channel.cmo lm_unix_util.cmo lm_db.cmo lm_notify.cmo lm_fs_case_sensitive.cmo lm_wild.cmo lm_readline.cmo lm_marshal.cmo lm_handle_table.cmo lm_int_handle_table.cmo lm_bitset.cmo lm_instrument.cmo
+CMXFILES_lm = lm_printf.cmx lm_debug.cmx lm_heap.cmx lm_list_util.cmx lm_array_util.cmx lm_set_sig.cmx lm_set.cmx lm_map_sig.cmx lm_map.cmx lm_int_set.cmx lm_termsize.cmx lm_terminfo.cmx lm_arg.cmx lm_index.cmx lm_thread_sig.cmx lm_thread_core.cmx lm_thread.cmx lm_string_util.cmx lm_string_set.cmx lm_hash.cmx lm_hash_code.cmx lm_symbol.cmx lm_location.cmx lm_position.cmx lm_filename_util.cmx lm_uname.cmx lm_thread_pool.cmx lm_channel.cmx lm_unix_util.cmx lm_db.cmx lm_notify.cmx lm_fs_case_sensitive.cmx lm_wild.cmx lm_readline.cmx lm_marshal.cmx lm_handle_table.cmx lm_int_handle_table.cmx lm_bitset.cmx lm_instrument.cmx
 OCAML_LIB_FLAGS_lm =
 
 lm.cma: $(CMOFILES_lm)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_lm) -a -o $@ $(CMOFILES_lm)
+lm.cmxa: $(CMXFILES_lm)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_lm) -a -o $@ $(CMXFILES_lm)
 
 lm_thread_pool.ml: ..$(slash)src$(slash)libmojave$(slash)lm_thread_pool_$(system).ml
 	$(LN) ..$(slash)src$(slash)libmojave$(slash)lm_thread_pool_$(system).ml lm_thread_pool.ml
@@ -368,10 +370,13 @@ ALLFILES_libmojave = lm_arg.ml lm_arg.mli lm_array_util.ml lm_array_util.mli lm_
 
 
 CMOFILES_frt = lm_hash_cons.cmo lm_lexer.cmo lm_parser.cmo lm_glob.cmo
+CMXFILES_frt = lm_hash_cons.cmx lm_lexer.cmx lm_parser.cmx lm_glob.cmx
 OCAML_LIB_FLAGS_frt =
 
 frt.cma: $(CMOFILES_frt)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_frt) -a -o $@ $(CMOFILES_frt)
+frt.cmxa: $(CMXFILES_frt)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_frt) -a -o $@ $(CMXFILES_frt)
 
 SRC_front = ..$(slash)src$(slash)front
 
@@ -403,19 +408,29 @@ ALLFILES_front = lm_glob.ml lm_glob.mli lm_hash_cons.ml lm_hash_cons.mli lm_lexe
 
 
 CMOFILES_omake_gen_magic = omake_gen_magic.cmo
+CMXFILES_omake_gen_magic = omake_gen_magic.cmx
 OCAML_LIBS_omake_gen_magic = lm.cma frt.cma
+OCAML_LIBS_OPT_omake_gen_magic = lm.cmxa frt.cmxa
 OCAML_OTHER_LIBS_omake_gen_magic = unix.cma
+OCAML_OTHER_LIBS_OPT_omake_gen_magic = unix.cmxa
 OCAML_CLIBS_omake_gen_magic = clib$(EXT_LIB)
 OCAML_CCLIBS_omake_gen_magic = -cclib clib$(EXT_LIB)
 
-omake_gen_magic$(EXE): $(CMOFILES_omake_gen_magic) $(OCAML_LIBS_omake_gen_magic) $(OCAML_CLIBS_omake_gen_magic)
+omake_gen_magic.byte$(EXE): $(CMOFILES_omake_gen_magic) $(OCAML_LIBS_omake_gen_magic) $(OCAML_CLIBS_omake_gen_magic)
 	$(OCAMLC) $(OCAMLFLAGS) -custom -o $@ $(OCAML_CCLIBS_omake_gen_magic) $(OCAML_OTHER_LIBS_omake_gen_magic) $(THREADSLIB) $(OCAML_LIBS_omake_gen_magic) $(CMOFILES_omake_gen_magic)
+omake_gen_magic.opt$(EXE): $(CMXFILES_omake_gen_magic) $(OCAML_LIBS_OPT_omake_gen_magic) $(OCAML_CLIBS_omake_gen_magic)
+	$(OCAMLOPT) $(OCAMLFLAGS) -o $@ $(OCAML_CCLIBS_omake_gen_magic) $(OCAML_OTHER_LIBS_OPT_omake_gen_magic) $(THREADSLIB) $(OCAML_LIBS_OPT_omake_gen_magic) $(CMXFILES_omake_gen_magic)
+omake_gen_magic$(EXE): omake_gen_magic$(PREFERRED)$(EXE)
+	$(LN) omake_gen_magic$(PREFERRED)$(EXE) $@
 
 CMOFILES_magic = omake_magic.cmo
+CMXFILES_magic = omake_magic.cmx
 OCAML_LIB_FLAGS_magic =
 
 magic.cma: $(CMOFILES_magic)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_magic) -a -o $@ $(CMOFILES_magic)
+magic.cmxa: $(CMXFILES_magic)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_magic) -a -o $@ $(CMXFILES_magic)
 
 GENMAGIC_DEPS = lm_filename_util.ml lm_hash.ml lm_location.ml lm_map.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache.ml omake_cache_type.ml omake_node.ml omake_command_digest.ml lm_filename_util.ml lm_hash.ml lm_location.ml lm_symbol.ml lm_map.ml lm_set.ml omake_node.ml omake_ir.ml lm_filename_util.ml lm_hash.ml lm_lexer.ml lm_location.ml lm_map.ml lm_parser.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache_type.ml omake_ir.ml omake_node.ml omake_env.ml version.txt
 MAGIC_FILES =    --cache-files lm_filename_util.ml lm_hash.ml lm_location.ml lm_map.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache.ml omake_cache_type.ml omake_node.ml omake_command_digest.ml    --omc-files lm_filename_util.ml lm_hash.ml lm_location.ml lm_symbol.ml lm_map.ml lm_set.ml omake_node.ml omake_ir.ml    --omo-files lm_filename_util.ml lm_hash.ml lm_lexer.ml lm_location.ml lm_map.ml lm_parser.ml lm_position.ml lm_set.ml lm_symbol.ml omake_value_type.ml omake_cache_type.ml omake_ir.ml omake_node.ml omake_env.ml
@@ -432,12 +447,15 @@ ALLFILES_magic = omake_gen_magic.ml
 
 
 CMOFILES_ir = omake_options.cmo omake_symbol.cmo omake_state.cmo omake_node_type.cmo omake_node_sig.cmo omake_node.cmo omake_install.cmo omake_ir.cmo omake_var.cmo omake_ir_util.cmo omake_ir_print.cmo omake_ir_free_vars.cmo omake_lexer.cmo omake_parser.cmo omake_value_type.cmo omake_command_type.cmo omake_value_util.cmo omake_value_print.cmo omake_pos.cmo omake_shell_type.cmo omake_command.cmo omake_cache_type.cmo omake_cache.cmo
+CMXFILES_ir = omake_options.cmx omake_symbol.cmx omake_state.cmx omake_node_type.cmx omake_node_sig.cmx omake_node.cmx omake_install.cmx omake_ir.cmx omake_var.cmx omake_ir_util.cmx omake_ir_print.cmx omake_ir_free_vars.cmx omake_lexer.cmx omake_parser.cmx omake_value_type.cmx omake_command_type.cmx omake_value_util.cmx omake_value_print.cmx omake_pos.cmx omake_shell_type.cmx omake_command.cmx omake_cache_type.cmx omake_cache.cmx
 OCAML_LIB_FLAGS_ir =
 
 ir.cma: $(CMOFILES_ir)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ir) -a -o $@ $(CMOFILES_ir)
+ir.cmxa: $(CMXFILES_ir)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ir) -a -o $@ $(CMXFILES_ir)
 
-omake_options.cmo omake_symbol.cmo omake_state.cmo omake_node_type.cmo omake_node_sig.cmo omake_node.cmo omake_install.cmo omake_ir.cmo omake_var.cmo omake_ir_util.cmo omake_ir_print.cmo omake_ir_free_vars.cmo omake_lexer.cmo omake_parser.cmo omake_value_type.cmo omake_command_type.cmo omake_value_util.cmo omake_value_print.cmo omake_pos.cmo omake_shell_type.cmo omake_command.cmo omake_cache_type.cmo omake_cache.cmo omake_options.cmi omake_state.cmi omake_node.cmi omake_install.cmi omake_var.cmi omake_ir_print.cmi omake_ir_free_vars.cmi omake_command_type.cmi omake_value_util.cmi omake_value_print.cmi omake_pos.cmi omake_command.cmi omake_cache.cmi: magic.cma
+omake_options.cmx omake_symbol.cmx omake_state.cmx omake_node_type.cmx omake_node_sig.cmx omake_node.cmx omake_install.cmx omake_ir.cmx omake_var.cmx omake_ir_util.cmx omake_ir_print.cmx omake_ir_free_vars.cmx omake_lexer.cmx omake_parser.cmx omake_value_type.cmx omake_command_type.cmx omake_value_util.cmx omake_value_print.cmx omake_pos.cmx omake_shell_type.cmx omake_command.cmx omake_cache_type.cmx omake_cache.cmx omake_options.cmo omake_symbol.cmo omake_state.cmo omake_node_type.cmo omake_node_sig.cmo omake_node.cmo omake_install.cmo omake_ir.cmo omake_var.cmo omake_ir_util.cmo omake_ir_print.cmo omake_ir_free_vars.cmo omake_lexer.cmo omake_parser.cmo omake_value_type.cmo omake_command_type.cmo omake_value_util.cmo omake_value_print.cmo omake_pos.cmo omake_shell_type.cmo omake_command.cmo omake_cache_type.cmo omake_cache.cmo omake_options.cmi omake_state.cmi omake_node.cmi omake_install.cmi omake_var.cmi omake_ir_print.cmi omake_ir_free_vars.cmi omake_command_type.cmi omake_value_util.cmi omake_value_print.cmi omake_pos.cmi omake_command.cmi omake_cache.cmi: magic.cma
 
 SRC_ir = ..$(slash)src$(slash)ir
 
@@ -553,10 +571,13 @@ ALLFILES_ir = omake_cache.ml omake_cache.mli omake_cache_type.ml omake_command.m
 
 
 CMOFILES_exec = omake_exec_id.cmo omake_exec_type.cmo omake_exec_print.cmo omake_exec_util.cmo omake_exec_local.cmo omake_exec_remote.cmo omake_exec_notify.cmo omake_exec.cmo
+CMXFILES_exec = omake_exec_id.cmx omake_exec_type.cmx omake_exec_print.cmx omake_exec_util.cmx omake_exec_local.cmx omake_exec_remote.cmx omake_exec_notify.cmx omake_exec.cmx
 OCAML_LIB_FLAGS_exec =
 
 exec.cma: $(CMOFILES_exec)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_exec) -a -o $@ $(CMOFILES_exec)
+exec.cmxa: $(CMXFILES_exec)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_exec) -a -o $@ $(CMXFILES_exec)
 
 SRC_exec = ..$(slash)src$(slash)exec
 
@@ -609,10 +630,13 @@ ALLFILES_exec = omake_exec.ml omake_exec.mli omake_exec_id.ml omake_exec_id.mli 
 
 
 CMOFILES_ast = omake_ast.cmo omake_ast_util.cmo omake_ast_print.cmo
+CMXFILES_ast = omake_ast.cmx omake_ast_util.cmx omake_ast_print.cmx
 OCAML_LIB_FLAGS_ast =
 
 ast.cma: $(CMOFILES_ast)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ast) -a -o $@ $(CMOFILES_ast)
+ast.cmxa: $(CMXFILES_ast)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_ast) -a -o $@ $(CMXFILES_ast)
 
 SRC_ast = ..$(slash)src$(slash)ast
 
@@ -635,19 +659,29 @@ ALLFILES_ast = omake_ast.ml omake_ast_print.ml omake_ast_print.mli omake_ast_uti
 
 
 CMOFILES_omake_gen_parse = omake_gen_parse.cmo
+CMXFILES_omake_gen_parse = omake_gen_parse.cmx
 OCAML_LIBS_omake_gen_parse =
+OCAML_LIBS_OPT_omake_gen_parse =
 OCAML_OTHER_LIBS_omake_gen_parse = unix.cma
+OCAML_OTHER_LIBS_OPT_omake_gen_parse = unix.cmxa
 OCAML_CLIBS_omake_gen_parse =
 OCAML_CCLIBS_omake_gen_parse =
 
-omake_gen_parse$(EXE): $(CMOFILES_omake_gen_parse) $(OCAML_LIBS_omake_gen_parse) $(OCAML_CLIBS_omake_gen_parse)
+omake_gen_parse.byte$(EXE): $(CMOFILES_omake_gen_parse) $(OCAML_LIBS_omake_gen_parse) $(OCAML_CLIBS_omake_gen_parse)
 	$(OCAMLC) $(OCAMLFLAGS) -custom -o $@ $(OCAML_CCLIBS_omake_gen_parse) $(OCAML_OTHER_LIBS_omake_gen_parse) $(THREADSLIB) $(OCAML_LIBS_omake_gen_parse) $(CMOFILES_omake_gen_parse)
+omake_gen_parse.opt$(EXE): $(CMXFILES_omake_gen_parse) $(OCAML_LIBS_OPT_omake_gen_parse) $(OCAML_CLIBS_omake_gen_parse)
+	$(OCAMLOPT) $(OCAMLFLAGS) -o $@ $(OCAML_CCLIBS_omake_gen_parse) $(OCAML_OTHER_LIBS_OPT_omake_gen_parse) $(THREADSLIB) $(OCAML_LIBS_OPT_omake_gen_parse) $(CMXFILES_omake_gen_parse)
+omake_gen_parse$(EXE): omake_gen_parse$(PREFERRED)$(EXE)
+	$(LN) omake_gen_parse$(PREFERRED)$(EXE) $@
 
 CMOFILES_env = omake_env.cmo omake_exn_print.cmo omake_ast_parse.cmo omake_ast_lex.cmo omake_exp_parse.cmo omake_exp_lex.cmo omake_ir_ast.cmo omake_ir_semant.cmo omake_command_digest.cmo
+CMXFILES_env = omake_env.cmx omake_exn_print.cmx omake_ast_parse.cmx omake_ast_lex.cmx omake_exp_parse.cmx omake_exp_lex.cmx omake_ir_ast.cmx omake_ir_semant.cmx omake_command_digest.cmx
 OCAML_LIB_FLAGS_env =
 
 env.cma: $(CMOFILES_env)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_env) -a -o $@ $(CMOFILES_env)
+env.cmxa: $(CMXFILES_env)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_env) -a -o $@ $(CMXFILES_env)
 
 GENPARSE = omake_gen_parse
 omake_ast_parse.mly: $(GENPARSE)$(EXE) omake_ast_parse.input
@@ -671,7 +705,7 @@ omake_ast_parse.input: ..$(slash)src$(slash)env$(slash)omake_ast_parse.input
 omake_exp_parse.mly: ..$(slash)src$(slash)env$(slash)omake_exp_parse.mly
 	$(LN) ..$(slash)src$(slash)env$(slash)omake_exp_parse.mly omake_exp_parse.mly
 
-omake_env.cmo omake_exn_print.cmo omake_ast_parse.cmo omake_ast_lex.cmo omake_exp_parse.cmo omake_exp_lex.cmo omake_ir_ast.cmo omake_ir_semant.cmo omake_command_digest.cmo omake_env.cmi omake_exn_print.cmi omake_ast_parse.cmi omake_ast_lex.cmi omake_exp_parse.cmi omake_exp_lex.cmi omake_ir_ast.cmi omake_ir_semant.cmi omake_command_digest.cmi: magic.cma
+omake_env.cmx omake_exn_print.cmx omake_ast_parse.cmx omake_ast_lex.cmx omake_exp_parse.cmx omake_exp_lex.cmx omake_ir_ast.cmx omake_ir_semant.cmx omake_command_digest.cmx omake_env.cmo omake_exn_print.cmo omake_ast_parse.cmo omake_ast_lex.cmo omake_exp_parse.cmo omake_exp_lex.cmo omake_ir_ast.cmo omake_ir_semant.cmo omake_command_digest.cmo omake_env.cmi omake_exn_print.cmi omake_ast_parse.cmi omake_ast_lex.cmi omake_exp_parse.cmi omake_exp_lex.cmi omake_ir_ast.cmi omake_ir_semant.cmi omake_command_digest.cmi: magic.cma
 
 Makefile.dep: omake_ast_lex.ml omake_ast_parse.mly omake_ast_parse.mli omake_ast_parse.ml omake_exp_parse.ml omake_exp_parse.mli
 
@@ -723,10 +757,13 @@ ALLFILES_env = omake_ast_lex.mli omake_command_digest.ml omake_command_digest.ml
 
 
 CMOFILES_shell = omake_shell_parse.cmo omake_shell_lex.cmo omake_shell_spawn.cmo omake_shell_sys_type.cmo omake_shell_sys.cmo omake_shell_job.cmo omake_shell_completion.cmo
+CMXFILES_shell = omake_shell_parse.cmx omake_shell_lex.cmx omake_shell_spawn.cmx omake_shell_sys_type.cmx omake_shell_sys.cmx omake_shell_job.cmx omake_shell_completion.cmx
 OCAML_LIB_FLAGS_shell =
 
 shell.cma: $(CMOFILES_shell)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_shell) -a -o $@ $(CMOFILES_shell)
+shell.cmxa: $(CMXFILES_shell)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_shell) -a -o $@ $(CMXFILES_shell)
 
 omake_shell_parse.ml: omake_shell_parse.mly
 omake_shell_parse.mli: omake_shell_parse.mly
@@ -776,10 +813,13 @@ ALLFILES_shell = omake_shell_completion.ml omake_shell_completion.mli omake_shel
 
 
 CMOFILES_eval = omake_eval.cmo omake_value.cmo
+CMXFILES_eval = omake_eval.cmx omake_value.cmx
 OCAML_LIB_FLAGS_eval =
 
 eval.cma: $(CMOFILES_eval)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_eval) -a -o $@ $(CMOFILES_eval)
+eval.cmxa: $(CMXFILES_eval)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_eval) -a -o $@ $(CMXFILES_eval)
 
 SRC_eval = ..$(slash)src$(slash)eval
 
@@ -799,12 +839,15 @@ ALLFILES_eval = omake_eval.ml omake_eval.mli omake_value.ml omake_value.mli
 
 
 CMOFILES_build = omake_rule.cmo omake_build_type.cmo omake_build_tee.cmo omake_build_util.cmo omake_builtin_type.cmo omake_target.cmo omake_builtin.cmo omake_build.cmo
+CMXFILES_build = omake_rule.cmx omake_build_type.cmx omake_build_tee.cmx omake_build_util.cmx omake_builtin_type.cmx omake_target.cmx omake_builtin.cmx omake_build.cmx
 OCAML_LIB_FLAGS_build =
 
 build.cma: $(CMOFILES_build)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_build) -a -o $@ $(CMOFILES_build)
+build.cmxa: $(CMXFILES_build)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_build) -a -o $@ $(CMXFILES_build)
 
-omake_rule.cmo omake_build_type.cmo omake_build_tee.cmo omake_build_util.cmo omake_builtin_type.cmo omake_target.cmo omake_builtin.cmo omake_build.cmo omake_rule.cmi omake_build_tee.cmi omake_build_util.cmi omake_target.cmi omake_builtin.cmi omake_build.cmi: magic.cma
+omake_rule.cmx omake_build_type.cmx omake_build_tee.cmx omake_build_util.cmx omake_builtin_type.cmx omake_target.cmx omake_builtin.cmx omake_build.cmx omake_rule.cmo omake_build_type.cmo omake_build_tee.cmo omake_build_util.cmo omake_builtin_type.cmo omake_target.cmo omake_builtin.cmo omake_build.cmo omake_rule.cmi omake_build_tee.cmi omake_build_util.cmi omake_target.cmi omake_builtin.cmi omake_build.cmi: magic.cma
 
 SRC_build = ..$(slash)src$(slash)build
 
@@ -854,12 +897,15 @@ ALLFILES_build = omake_build.ml omake_build.mli omake_build_tee.ml omake_build_t
 
 
 CMOFILES_builtin = omake_printf.cmo omake_builtin_util.cmo omake_builtin_base.cmo omake_builtin_arith.cmo omake_builtin_file.cmo omake_builtin_fun.cmo omake_builtin_io.cmo omake_builtin_io_fun.cmo omake_builtin_sys.cmo omake_builtin_target.cmo omake_builtin_shell.cmo omake_builtin_rule.cmo omake_builtin_object.cmo omake_builtin_test.cmo omake_builtin_ocamldep.cmo
+CMXFILES_builtin = omake_printf.cmx omake_builtin_util.cmx omake_builtin_base.cmx omake_builtin_arith.cmx omake_builtin_file.cmx omake_builtin_fun.cmx omake_builtin_io.cmx omake_builtin_io_fun.cmx omake_builtin_sys.cmx omake_builtin_target.cmx omake_builtin_shell.cmx omake_builtin_rule.cmx omake_builtin_object.cmx omake_builtin_test.cmx omake_builtin_ocamldep.cmx
 OCAML_LIB_FLAGS_builtin = -linkall
 
 builtin.cma: $(CMOFILES_builtin)
 	$(OCAMLC) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_builtin) -a -o $@ $(CMOFILES_builtin)
+builtin.cmxa: $(CMXFILES_builtin)
+	$(OCAMLOPT) $(OCAMLFLAGS) $(OCAML_LIB_FLAGS_builtin) -a -o $@ $(CMXFILES_builtin)
 
-omake_printf.cmo omake_builtin_util.cmo omake_builtin_base.cmo omake_builtin_arith.cmo omake_builtin_file.cmo omake_builtin_fun.cmo omake_builtin_io.cmo omake_builtin_io_fun.cmo omake_builtin_sys.cmo omake_builtin_target.cmo omake_builtin_shell.cmo omake_builtin_rule.cmo omake_builtin_object.cmo omake_builtin_test.cmo omake_builtin_ocamldep.cmo omake_printf.cmi omake_builtin_util.cmi omake_builtin_base.cmi omake_builtin_arith.cmi omake_builtin_file.cmi omake_builtin_fun.cmi omake_builtin_io.cmi omake_builtin_io_fun.cmi omake_builtin_sys.cmi omake_builtin_target.cmi omake_builtin_shell.cmi omake_builtin_rule.cmi omake_builtin_object.cmi omake_builtin_test.cmi: magic.cma
+omake_printf.cmx omake_builtin_util.cmx omake_builtin_base.cmx omake_builtin_arith.cmx omake_builtin_file.cmx omake_builtin_fun.cmx omake_builtin_io.cmx omake_builtin_io_fun.cmx omake_builtin_sys.cmx omake_builtin_target.cmx omake_builtin_shell.cmx omake_builtin_rule.cmx omake_builtin_object.cmx omake_builtin_test.cmx omake_builtin_ocamldep.cmx omake_printf.cmo omake_builtin_util.cmo omake_builtin_base.cmo omake_builtin_arith.cmo omake_builtin_file.cmo omake_builtin_fun.cmo omake_builtin_io.cmo omake_builtin_io_fun.cmo omake_builtin_sys.cmo omake_builtin_target.cmo omake_builtin_shell.cmo omake_builtin_rule.cmo omake_builtin_object.cmo omake_builtin_test.cmo omake_builtin_ocamldep.cmo omake_printf.cmi omake_builtin_util.cmi omake_builtin_base.cmi omake_builtin_arith.cmi omake_builtin_file.cmi omake_builtin_fun.cmi omake_builtin_io.cmi omake_builtin_io_fun.cmi omake_builtin_sys.cmi omake_builtin_target.cmi omake_builtin_shell.cmi omake_builtin_rule.cmi omake_builtin_object.cmi omake_builtin_test.cmi: magic.cma
 
 SRC_builtin = ..$(slash)src$(slash)builtin
 
@@ -954,15 +1000,22 @@ ALLFILES_builtin = omake_builtin_arith.ml omake_builtin_arith.mli omake_builtin_
 
 
 CMOFILES_omake = omake_main_util.cmo omake_shell.cmo omake_main.cmo
+CMXFILES_omake = omake_main_util.cmx omake_shell.cmx omake_main.cmx
 OCAML_LIBS_omake = lm.cma frt.cma magic.cma ast.cma ir.cma env.cma exec.cma eval.cma shell.cma build.cma builtin.cma
+OCAML_LIBS_OPT_omake = lm.cmxa frt.cmxa magic.cmxa ast.cmxa ir.cmxa env.cmxa exec.cmxa eval.cmxa shell.cmxa build.cmxa builtin.cmxa
 OCAML_OTHER_LIBS_omake = unix.cma
+OCAML_OTHER_LIBS_OPT_omake = unix.cmxa
 OCAML_CLIBS_omake = clib$(EXT_LIB)
 OCAML_CCLIBS_omake = -cclib clib$(EXT_LIB)
 
-omake$(EXE): $(CMOFILES_omake) $(OCAML_LIBS_omake) $(OCAML_CLIBS_omake)
+omake.byte$(EXE): $(CMOFILES_omake) $(OCAML_LIBS_omake) $(OCAML_CLIBS_omake)
 	$(OCAMLC) $(OCAMLFLAGS) -custom -o $@ $(OCAML_CCLIBS_omake) $(OCAML_OTHER_LIBS_omake) $(THREADSLIB) $(OCAML_LIBS_omake) $(CMOFILES_omake)
+omake.opt$(EXE): $(CMXFILES_omake) $(OCAML_LIBS_OPT_omake) $(OCAML_CLIBS_omake)
+	$(OCAMLOPT) $(OCAMLFLAGS) -o $@ $(OCAML_CCLIBS_omake) $(OCAML_OTHER_LIBS_OPT_omake) $(THREADSLIB) $(OCAML_LIBS_OPT_omake) $(CMXFILES_omake)
+omake$(EXE): omake$(PREFERRED)$(EXE)
+	$(LN) omake$(PREFERRED)$(EXE) $@
 
-omake_main_util.cmo omake_shell.cmo omake_main.cmo omake_shell.cmi omake_main.cmi: magic.cma
+omake_main_util.cmx omake_shell.cmx omake_main.cmx omake_main_util.cmo omake_shell.cmo omake_main.cmo omake_shell.cmi omake_main.cmi: magic.cma
 
 SRC_main = ..$(slash)src$(slash)main
 


### PR DESCRIPTION
omake-boot doesn't require the old omake-boot to build itself, so there is no reason to restrict it to bytecode only (unlike OCaml itself where `/boot/ocamlc` is required).
This approximately halves the time needed for 'make bootstrap -j8 && make all' on an 8-core machine.

Caveats:
 * tested only on Linux
 * on rare occasions you get inconsistent assumptions with the native build and `make bootstrap -j 8`, in which case it falls back to the bytecode build, looks like some missing rules for cmi when its built directly from .ml:
```
Error: Files omake_shell_sys.cmx and omake_shell_sys_type.cmx
       make inconsistent assumptions over interface Omake_shell_sys_type
Makefile:767: recipe for target 'shell.cmxa' failed

ocamlopt.opt -w +a-4-32-30-42-40-41 -g  -c lm_lexer.ml
File "_none_", line 1:
Error: Files lm_map.cmx and lm_map_sig.cmx
       make inconsistent assumptions over interface Lm_map_sig

File "omake_parser.ml", line 1:
Error: Corrupted compiled interface
omake_lexer.cmi
```

