### PR TITLE
Fix FAM support

### DIFF
--- a/lib/configure/Configure.om
+++ b/lib/configure/Configure.om
@@ -266,7 +266,7 @@ public.VerboseCheckCHeader(files) =
 # \end{doc}
 #
 public.CheckCLib(libs, funs) =
-    CFLAGS += $(addprefix -l, $(libs))
+    LDFLAGS += $(addprefix -l, $(libs))
 
     return $(TryLinkC $"""
 #ifdef __cplusplus


### PR DESCRIPTION
Installing omake with opam yielded an omake that didn't have FAM linked,
thus the useful -P option was not available. This was due to a change
described here https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition

With the given patch, omake compiles again with FAM support.

Ferrying patches from the opam-repository for official inclusion.

cc @seanmcl