### PR TITLE
Fix omake on netbsd

### DIFF
--- a/src/clib/fam_kqueue.c
+++ b/src/clib/fam_kqueue.c
@@ -181,6 +181,12 @@ static kevent_t *new_kevent() {
     return ev;
 }
 
+#if defined(__NetBSD__)
+typedef intptr_t kqueue_udata_t;
+#else
+typedef void *kqueue_udata_t;
+#endif
+
 /*
  * Start monitoring a directory.
  * We store the DirInfo pointer as the userdata in the kevent.
@@ -199,7 +205,7 @@ static int monitor_start(FAMConnection *fc, DirInfo *dir)
         dir->kevent = kev;
         /* Register interest in the MON_FLAGS flags of the dir */
         EV_SET(kev, dir->handle, EVFILT_VNODE, EV_ADD | EV_CLEAR, MON_FLAGS,
-                (intptr_t) NULL, (void *)dir);
+                (intptr_t) NULL, (kqueue_udata_t) dir);
         code = kevent(fc->id, kev, 1, NULL, 0, &gTime0);
 #ifdef FAM_DEBUG
         fprintf(stderr,


### PR DESCRIPTION
Omake fails to build on NetBSD, because the use of a -Werror in one
compilation step causes a warning about a kqueue-related typecast to
become an error and aborts build. The native NetBSD package building
framework, pkgsrc, contains a patch to workaround this issue. This
commit reproduces that patch here.

Originally from: https://github.com/ocaml/opam-repository/pull/3939