### PR TITLE
windows: workaround for fchmod

### DIFF
--- a/src/libmojave/lm_unix_util.ml
+++ b/src/libmojave/lm_unix_util.ml
@@ -80,7 +80,10 @@ let copy_file from_name to_name mode =
        need_close to_fd 
          (function to_fd ->
            copy_file_fd (Bytes.create 8192) from_fd to_fd; 
-           Unix.fchmod to_fd mode
+           if Sys.os_type <> "Win32" then
+             Unix.fchmod to_fd mode
+           else
+             Unix.chmod to_name mode
          )  )
 
 


### PR DESCRIPTION
fchmod is currently not implemented:
https://github.com/ocaml/ocaml/blob/59a4fd6615454362aba2b7c4c5ea788d19edd739/otherlibs/win32unix/unix.ml#L303