### PR TITLE
use ocamldep.opt only when not using ocamlfind

### DIFF
--- a/lib/build/OCaml.om
+++ b/lib/build/OCaml.om
@@ -129,7 +129,7 @@ public.OCAMLFIND = $`(if $(USE_OCAMLFIND), ocamlfind)
 public.OCAMLFINDFLAGS =
 public.LAZY_OCAMLFINDFLAGS = $`(if $(USE_OCAMLFIND), $(OCAMLFINDFLAGS))
 
-public.OCAMLDEP = $(if $(OCAMLDEP_OPT_EXISTS), ocamldep.opt, ocamldep)
+public.OCAMLDEP = $(if $(OCAMLDEP_OPT_EXISTS), $`(if $(USE_OCAMLFIND), ocamldep, ocamldep.opt), ocamldep)
 public.CAMLP4 = camlp4
 public.OCAMLLEX = $(if $(OCAMLLEX_OPT_EXISTS), ocamllex.opt, ocamllex)
 public.OCAMLLEXFLAGS = -q


### PR DESCRIPTION
ocamlfind already knows how to pick the right one, and it doesn't accept
'ocamlfind ocamldep.opt'.
This is similar to how ocamlc.opt and ocamlopt.opt is picked.

See discussion at https://github.com/gerdstolpmann/omake/pull/2#issuecomment-192696463